### PR TITLE
BF: Validate tracking algorithm and number of arguments

### DIFF
--- a/code/DiSCo_connectivity_pipeline.sh
+++ b/code/DiSCo_connectivity_pipeline.sh
@@ -43,12 +43,6 @@ out_path=""
 # Parse input arguments
 PARAMS=""
 
-if [ "$#" -ne 7 ]
-then
-  echo "Error: Missing mandatory arguments"
-  usage
-fi
-
 while (( "$#" )); do
   case "$1" in
     -h)
@@ -67,6 +61,12 @@ done
 
 # Set positional arguments in their proper place
 eval set -- "$PARAMS"
+
+if [ "$#" -ne 7 ]
+then
+  echo "Error: Missing mandatory arguments"
+  usage
+fi
 
 in_dwi=$1
 in_bval=$2

--- a/code/DiSCo_connectivity_pipeline.sh
+++ b/code/DiSCo_connectivity_pipeline.sh
@@ -27,14 +27,9 @@
 # e.g. ./DiSCo_connectivity_pipeline.sh DiSCo_DWI_shell_full.nii.gz DiSCo_DWI_shell_full.bval DiSCo_DWI_shell_full.bvec DiSCo1_ROIs.nii.gz DiSCo1_Connectivity_Matrix_Cross-Sectional_Area.txt pft outpath/
 
 usage() {
-  echo "$(basename $0) \
-        [in_dwi] \
-        [in_bval] \
-        [in_bvec] \
-        [in_rois] \
-        [in_connectivity_truth] \
-        [tracking_method] \
-        [out_path]"; exit 1;
+  msg="Usage: $(basename $0) [in_dwi] [in_bval] [in_bvec] [in_rois]"
+  msg="$msg [in_connectivity_truth] [tracking_method] [out_path]"
+  echo "$msg"; exit 1;
 }
 
 in_dwi=""
@@ -47,6 +42,12 @@ out_path=""
 
 # Parse input arguments
 PARAMS=""
+
+if [ "$#" -ne 7 ]
+then
+  echo "Error: Missing mandatory arguments"
+  usage
+fi
 
 while (( "$#" )); do
   case "$1" in
@@ -76,16 +77,16 @@ tracking_method=$6
 out_path=$7
 
 dict_tracking_method=('local' 'pft')
-method_exists=False
+method_exists=false
 
-for method in $dict_tracking_method
+for method in "${dict_tracking_method[@]}"
 do 
 	if [ "$tracking_method" == "$method" ]; then
-		method_exists=True
+		method_exists=true
 	fi
 done
 
-if !$method_exists; then 
+if ! $method_exists; then 
 	echo "Tracking method is not valid. Use 'local' or 'pft'"
 	exit 0
 fi


### PR DESCRIPTION
Nothing critical here, but the code section where the tracking method is validated did not work for me. It would just print 
```
code/DiSCo_connectivity_pipeline.sh: line 88: !False: command not found
``` 
or 
```
code/DiSCo_connectivity_pipeline.sh: line 88: !True: command not found
```
and continue on with the execution.

I also added a check on the number of mandatory arguments to exit right away if the script is not used correctly. Also the usage message did not format nicely due to the extra spaces in the string, so I fixed that at the same time.

Makes sense?